### PR TITLE
Fix %worth% plaecholder, AsyncPlayerChatEvent, and Citizens trait

### DIFF
--- a/src/main/java/conj/shop/Initiate.java
+++ b/src/main/java/conj/shop/Initiate.java
@@ -159,7 +159,7 @@ public class Initiate extends JavaPlugin {
         // Citizens
         if (Bukkit.getPluginManager().getPlugin("Citizens") != null) {
             try {
-            	CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(NPCAddon.class).withName("shop"));
+                CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(NPCAddon.class).withName("shop"));
                 Initiate.citizens = true;
                 this.getLogger().info("Successfully hooked into Citizens.");
             } catch (NullPointerException | NoClassDefFoundError npe) {
@@ -175,7 +175,9 @@ public class Initiate extends JavaPlugin {
     }
 
     public void onDisable() {
-    	CitizensAPI.getTraitFactory().deregisterTrait(TraitInfo.create(NPCAddon.class).withName("shop"));
+        if (Initiate.citizens) {
+            CitizensAPI.getTraitFactory().deregisterTrait(TraitInfo.create(NPCAddon.class).withName("shop"));
+        }
         Autosave.save();
     }
 

--- a/src/main/java/conj/shop/Initiate.java
+++ b/src/main/java/conj/shop/Initiate.java
@@ -159,7 +159,7 @@ public class Initiate extends JavaPlugin {
         // Citizens
         if (Bukkit.getPluginManager().getPlugin("Citizens") != null) {
             try {
-                CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(NPCAddon.class).withName("shop"));
+            	CitizensAPI.getTraitFactory().registerTrait(TraitInfo.create(NPCAddon.class).withName("shop"));
                 Initiate.citizens = true;
                 this.getLogger().info("Successfully hooked into Citizens.");
             } catch (NullPointerException | NoClassDefFoundError npe) {

--- a/src/main/java/conj/shop/Initiate.java
+++ b/src/main/java/conj/shop/Initiate.java
@@ -175,6 +175,7 @@ public class Initiate extends JavaPlugin {
     }
 
     public void onDisable() {
+    	CitizensAPI.getTraitFactory().deregisterTrait(TraitInfo.create(NPCAddon.class).withName("shop"));
         Autosave.save();
     }
 

--- a/src/main/java/conj/shop/commands/control/Manager.java
+++ b/src/main/java/conj/shop/commands/control/Manager.java
@@ -6,6 +6,7 @@ import conj.shop.data.Page;
 import conj.shop.data.PageSlot;
 import conj.shop.tools.ItemSerialize;
 import net.citizensnpcs.api.npc.NPC;
+
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/conj/shop/commands/control/Manager.java
+++ b/src/main/java/conj/shop/commands/control/Manager.java
@@ -6,7 +6,6 @@ import conj.shop.data.Page;
 import conj.shop.data.PageSlot;
 import conj.shop.tools.ItemSerialize;
 import net.citizensnpcs.api.npc.NPC;
-
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/conj/shop/data/Page.java
+++ b/src/main/java/conj/shop/data/Page.java
@@ -337,13 +337,14 @@ public class Page {
             }
             final Inventory open = player.getOpenInventory().getTopInventory();
             final List<Integer> slots = this.getVisibleSlots(player);
-            Initiate.log(player.getName() + " : " + this.getID() + " : " + DoubleUtil.toString(Shop.getInventoryWorth(player, open, this)));
+            double worth = Shop.getInventoryWorth(player, open, this);
+            Initiate.log(player.getName() + " : " + this.getID() + " : " + DoubleUtil.toString(worth));
             for (final int s : slots) {
                 final ItemStack i = this.getInventoryFlat(player).getItem(s);
                 if (i != null) {
                     final ItemCreator ic = new ItemCreator(i);
                     ic.placehold(player, this, s);
-                    ic.replace("%worth%", DoubleUtil.toString(Shop.getInventoryWorth(player, open, this)));
+                    ic.replace("%worth%", DoubleUtil.toString(worth));
                     open.setItem(s, ic.getItem());
                 }
             }
@@ -355,7 +356,6 @@ public class Page {
         if (!manage.getOpenPage(player).equalsIgnoreCase("")) {
             manage.setPreviousPage(player, manage.getOpenPage(player));
         }
-        manage.setOpenPage(player, this.id);
         final Inventory inv = this.getInventory(player);
         if (this.getFill() != null) {
             final InventoryCreator ic = new InventoryCreator(inv);

--- a/src/main/java/conj/shop/events/listeners/Input.java
+++ b/src/main/java/conj/shop/events/listeners/Input.java
@@ -61,7 +61,7 @@ public class Input implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void enterInput(final AsyncPlayerChatEvent event) {
         final Player player = event.getPlayer();
         if (this.player == null) {

--- a/src/main/java/conj/shop/events/listeners/Shop.java
+++ b/src/main/java/conj/shop/events/listeners/Shop.java
@@ -280,6 +280,7 @@ public class Shop implements Listener {
                     if (first2 != -1 && worth > 0.0) {
                         top.setItem(first2, item);
                         player.getInventory().setItem(event.getSlot(), null);
+                        Manager.get().setOpenPage(player, page.getID());
                         page.updateView(player, false);
                     }
                 }


### PR DESCRIPTION
Just some minor updates:

- Reduce some extra calls to getInventoryWorth
- Call setOpenPage prior to updating the page view for a player when using the sell GUI, otherwise getopenpages returns null
- Change AsyncPlayerChatEvent priority to LOWEST since we don't need to know if other plugins tried to cancel it. This way, other plugins can see that we cancel it and won't try to format the message in chat.
- Deregister the Citizens trait on plugin disable to allow the plugin to be reloaded.